### PR TITLE
添加合并操作函数，文字绘制优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install --save wxml-to-canvas
 
 ```
 <video class="video" src="{{src}}">
-  <wxml-to-canvas class="widget"></wxml-to-canvas>
+  <wxml-to-canvas class="widget" bind:canvasReady="getImage"></wxml-to-canvas>
 </video>
 <image src="{{src}}" style="width: {{width}}px; height: {{height}}px"></image>
 ```
@@ -160,6 +160,11 @@ const style = {
 #### f3. `wxmlToCanvasToImg({wxml, style}): Promise`
 
 串联wxml渲染到canvas和提取画布内容生成图片两个操作
+
+#### f4. `canvasReady`
+
+组件中canvas初始化完成的回调函数，可结合`wxmlToCanvasToImg`搭配使用，实现应用组件页面中立即得到图片。
+
 
 ## 支持的 css 属性
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ const style = {
 
 `fileType` 支持 `jpg`、`png` 两种格式，quality 为图片的质量，目前仅对 jpg 有效。取值范围为 (0, 1]，不在范围内时当作 1.0 处理。
 
-#### f3. `getImage({wxml, style}): Promise`
+#### f3. `wxmlToCanvasToImg({wxml, style}): Promise`
 
 串联wxml渲染到canvas和提取画布内容生成图片两个操作
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Page({
   onLoad() {
     this.widget = this.selectComponent('.widget')
   },
+  getImage() {
+    const p1 = this.widget.wxmlToCanvasToImg({wxml, style})
+    p1.then(res => {
+      this.setData({
+        src: res.tempFilePath,
+        width: res.container.layoutBox.width,
+        height: res.container.layoutBox.height
+      })
+    }).catch(res => console.error(res))
+  },
   renderToCanvas() {
     const p1 = this.widget.renderToCanvas({ wxml, style })
     p1.then((res) => {
@@ -71,6 +81,12 @@ Page({
   }
 })
 ```
+
+#### Step5. 修改编译选项
+
+1. 详情——本地设置——勾选"增强编译"
+2. 工具——构建npm
+
 
 ## wxml 模板
 
@@ -140,6 +156,10 @@ const style = {
 提取画布中容器所在区域内容生成相同大小的图片，返回临时文件地址。
 
 `fileType` 支持 `jpg`、`png` 两种格式，quality 为图片的质量，目前仅对 jpg 有效。取值范围为 (0, 1]，不在范围内时当作 1.0 处理。
+
+#### f3. `getImage({wxml, style}): Promise`
+
+串联wxml渲染到canvas和提取画布内容生成图片两个操作
 
 ## 支持的 css 属性
 

--- a/src/hex-to-rgba.js
+++ b/src/hex-to-rgba.js
@@ -1,0 +1,63 @@
+const removeHash = hex => (hex.charAt(0) === '#' ? hex.slice(1) : hex);
+
+const parseHex = (nakedHex) => {
+    const isShort = (
+        nakedHex.length === 3
+        || nakedHex.length === 4
+    );
+
+    const twoDigitHexR = isShort ? `${nakedHex.slice(0, 1)}${nakedHex.slice(0, 1)}` : nakedHex.slice(0, 2);
+    const twoDigitHexG = isShort ? `${nakedHex.slice(1, 2)}${nakedHex.slice(1, 2)}` : nakedHex.slice(2, 4);
+    const twoDigitHexB = isShort ? `${nakedHex.slice(2, 3)}${nakedHex.slice(2, 3)}` : nakedHex.slice(4, 6);
+    const twoDigitHexA = ((isShort ? `${nakedHex.slice(3, 4)}${nakedHex.slice(3, 4)}` : nakedHex.slice(6, 8)) || 'ff');
+
+    // const numericA = +((parseInt(a, 16) / 255).toFixed(2));
+
+    return {
+        r: twoDigitHexR,
+        g: twoDigitHexG,
+        b: twoDigitHexB,
+        a: twoDigitHexA,
+    };
+};
+
+const hexToDecimal = hex => parseInt(hex, 16);
+
+const hexesToDecimals = ({
+                             r, g, b, a,
+                         }) => ({
+    r: hexToDecimal(r),
+    g: hexToDecimal(g),
+    b: hexToDecimal(b),
+    a: +((hexToDecimal(a) / 255).toFixed(2)),
+});
+
+const isNumeric = n => !isNaN(parseFloat(n)) && isFinite(n); // eslint-disable-line no-restricted-globals, max-len
+
+const formatRgb = (decimalObject, parameterA) => {
+    const {
+        r, g, b, a: parsedA,
+    } = decimalObject;
+    const a = isNumeric(parameterA) ? parameterA : parsedA;
+
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+};
+
+/**
+ * Turns an old-fashioned css hex color value into a rgb color value.
+ *
+ * If you specify an alpha value, you'll get a rgba() value instead.
+ *
+ * @param The hex value to convert. ('123456'. '#123456', ''123', '#123')
+ * @param An alpha value to apply. (optional) ('0.5', '0.25')
+ * @return An rgb or rgba value. ('rgb(11, 22, 33)'. 'rgba(11, 22, 33, 0.5)')
+ */
+const hexToRgba = (hex, a) => {
+    const hashlessHex = removeHash(hex);
+    const hexObject = parseHex(hashlessHex);
+    const decimalObject = hexesToDecimals(hexObject);
+
+    return formatRgb(decimalObject, a);
+};
+
+module.exports = hexToRgba;

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ Component({
         const childStyle = getStyle(style, child)
         const childClassName = child.attributes.class
         textCtx.draw(false)
-        textCtx.font = `normal normal normal normal ${childStyle.fontSize}px / ${childStyle.lineHeight || childStyle.height}px "PingFang SC"`
+        textCtx.font = `normal normal ${childStyle.fontWeight || 400} normal ${childStyle.fontSize}px / ${childStyle.lineHeight || childStyle.height}px "PingFang SC"`
         const metrics = textCtx.measureText(child.content)
 
         const canvasMeasureWidth = metrics.width

--- a/tools/demo/pages/index/index.js
+++ b/tools/demo/pages/index/index.js
@@ -7,6 +7,17 @@ Page({
   onLoad() {
     this.widget = this.selectComponent('.widget')
   },
+  // 直接获取img
+  getImage() {
+    const p1 = this.widget.wxmlToCanvasToImg({wxml, style})
+    p1.then(res => {
+      this.setData({
+        src: res.tempFilePath,
+        width: res.container.layoutBox.width,
+        height: res.container.layoutBox.height
+      })
+    }).catch(res => console.error(res))
+  },
   renderToCanvas() {
     const p1 = this.widget.renderToCanvas({ wxml, style })
     p1.then((res) => {

--- a/tools/demo/pages/index/index.wxml
+++ b/tools/demo/pages/index/index.wxml
@@ -1,5 +1,6 @@
 <wxml-to-canvas class="widget"></wxml-to-canvas>
 <button bindtap="renderToCanvas">渲染到canvas</button>
 <button bindtap="extraImage">导出图片</button>
+<button bindtap="getImage">直接导出图片</button>
 
 <image src="{{src}}" style="width: {{width}}px; height: {{height}}px"></image>

--- a/tools/demo/pages/index/index.wxml
+++ b/tools/demo/pages/index/index.wxml
@@ -1,4 +1,4 @@
-<wxml-to-canvas class="widget"></wxml-to-canvas>
+<wxml-to-canvas class="widget" bind:canvasReady="getImage"></wxml-to-canvas>
 <button bindtap="renderToCanvas">渲染到canvas</button>
 <button bindtap="extraImage">导出图片</button>
 <button bindtap="getImage">直接导出图片</button>

--- a/tools/demo/project.config.json
+++ b/tools/demo/project.config.json
@@ -6,6 +6,7 @@
 	"setting": {
 		"urlCheck": true,
 		"es6": true,
+		"enhance": true,
 		"postcss": true,
 		"minified": true,
 		"newFeature": true,


### PR DESCRIPTION
1. 大多数项目诉求是直接获取图片，修改了下封装添加了wxmlToCanvasToImg函数
2. `type=2d`的canvas获取context为异步过程，添加获取上下文成功回调
~~3. 文字宽度并没有真正动态布局，在canvas中重新计算文字宽度修改xom中的宽度，绘制时候判断不超出父元素允许换行~~（暂不添加）