### PR TITLE
增加 shouldClearRect 配置，允许在绘制前不清空 canvas

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ Component({
   },
   methods: {
     async renderToCanvas(args) {
-      const {wxml, style} = args
+      const {wxml, style, shouldClearRect = true} = args
       const ctx = this.ctx
       const canvas = this.canvas
       const use2dCanvas = this.data.use2dCanvas
@@ -56,7 +56,9 @@ Component({
         return Promise.reject(new Error('renderToCanvas: fail canvas has not been created'))
       }
 
-      ctx.clearRect(0, 0, this.data.width, this.data.height)
+      if (shouldClearRect) {
+        ctx.clearRect(0, 0, this.data.width, this.data.height)
+      }
       const {root: xom} = xmlParse(wxml)
 
       const widget = new Widget(xom, style)


### PR DESCRIPTION
背景：因为 wxml-to-canvas 不支持渐变色背景，所以希望在调用 renderToCanvas 之前，能够允许业务方自行对 canvas 进行一些绘制。然后目前 renderToCanvas 会清空 canvas 画布，导致业务方自行绘制的数据失效，因为增加 shouldClearRect 进行配置。

绘制渐变色背景图例子：

```js
const { ctx } = this.wxmlToCanvasWidget;
// wxml-to-canvas 不支持渐变背景色，自行实现
  ctx.save();
  const {
    canvasHeight,
    canvasWidth,
  } = this.data;
  const grd = ctx.createLinearGradient(0, 0, 0, canvasHeight);
  grd.addColorStop(0, '#FF6E55');
  grd.addColorStop(1, '#EB4225');

  ctx.fillStyle = grd;
  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
  ctx.restore();

  this.wxmlToCanvasWidget.renderToCanvas({
    wxml,
    style,
    shouldClearRect: false,
  }).then((res) => { ... });
```